### PR TITLE
feat: 启用 PublishTrimmed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,7 +188,7 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
+# *.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/DotVast.HashTool.WinUI/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/DotVast.HashTool.WinUI/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>arm64</Platform>
+    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>True</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <PublishTrimmed>False</PublishTrimmed>
+    <PublishReadyToRun>False</PublishReadyToRun>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+    <PublishTrimmed>True</PublishTrimmed>
+    <PublishReadyToRun>True</PublishReadyToRun>
+  </PropertyGroup>
+</Project>

--- a/DotVast.HashTool.WinUI/Properties/PublishProfiles/win10-x64.pubxml
+++ b/DotVast.HashTool.WinUI/Properties/PublishProfiles/win10-x64.pubxml
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+    <DebugType>none</DebugType>
     <PublishTrimmed>True</PublishTrimmed>
     <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>

--- a/DotVast.HashTool.WinUI/Properties/PublishProfiles/win10-x64.pubxml
+++ b/DotVast.HashTool.WinUI/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>True</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <PublishTrimmed>False</PublishTrimmed>
+    <PublishReadyToRun>False</PublishReadyToRun>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+    <PublishTrimmed>True</PublishTrimmed>
+    <PublishReadyToRun>True</PublishReadyToRun>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
启用 PublishTrimmed 功能。

在 .Net 7 下存在 https://github.com/microsoft/WindowsAppSDK/issues/3030 问题，当该问题修复后合并。

在 .Net 6 下测试可知：启用该功能后，在 Release 模式下发布，本应用的安装大小从 138 MiB 减小到 53 MiB（减小 62%）。