### PR TITLE
refactor: 在本地设置的容器内保存哈希设置

### DIFF
--- a/src/DotVast.HashTool.WinUI/Constants.cs
+++ b/src/DotVast.HashTool.WinUI/Constants.cs
@@ -8,6 +8,12 @@ public static class CommandLineArgs
     public const string Path = "--path";
 }
 
+internal static class SettingsContainerName
+{
+    public const string ContextMenu = "ContextMenu";
+    public const string DataOptions_Hashes = "DataOptions:Hashes";
+}
+
 public static class GitHubRestApi
 {
     public const string BaseUrl = "https://api.github.com/";

--- a/src/DotVast.HashTool.WinUI/Contracts/Services/IHashService.cs
+++ b/src/DotVast.HashTool.WinUI/Contracts/Services/IHashService.cs
@@ -5,7 +5,7 @@ namespace DotVast.HashTool.WinUI.Contracts.Services;
 
 public interface IHashService
 {
-    HashKind[] AllHashes { get; }
+    HashKind[] HashKinds { get; }
 
     HashKind? GetHash(string hashName);
 
@@ -14,4 +14,17 @@ public interface IHashService
     HashData GetHashData(HashKind hash);
 
     IEnumerable<HashSetting> FillHashSettings(IEnumerable<HashSetting>? hashSettings);
+
+    /// <summary>
+    /// 将提供的设置合并到默认设置.
+    /// </summary>
+    /// <remarks>
+    /// 仅支持 <see cref="HashSetting.IsChecked"/>,
+    /// <see cref="HashSetting.IsEnabledForApp"/>,
+    /// <see cref="HashSetting.IsEnabledForContextMenu"/>
+    /// 属性的合并.
+    /// </remarks>
+    /// <param name="hashSettings">哈希设置.</param>
+    /// <returns>合并后的设置.</returns>
+    IEnumerable<HashSetting> MergeHashSettings(IList<HashSetting> hashSettings);
 }

--- a/src/DotVast.HashTool.WinUI/Contracts/Services/ILocalSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Contracts/Services/ILocalSettingsService.cs
@@ -1,12 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace DotVast.HashTool.WinUI.Contracts.Services;
 
 public interface ILocalSettingsService
 {
-    Task<(bool HasValue, T? Value)> ReadSettingAsync<T>(string key);
+    [return: NotNullIfNotNull(nameof(defaultValue))]
+    T? ReadSetting<T>(string key, T? defaultValue = default);
 
-    Task<(bool HasValue, T? Value)> ReadSettingAsync<T>(string containerName, string key);
+    [return: NotNullIfNotNull(nameof(defaultValue))]
+    T? ReadSetting<T>(string containerName, string key, T? defaultValue = default);
 
-    Task SaveSettingAsync<T>(string key, T value);
+    void SaveSetting<T>(string key, T value);
 
-    Task SaveSettingAsync<T>(string containerName, string key, T value);
+    void SaveSetting<T>(string containerName, string key, T value);
 }

--- a/src/DotVast.HashTool.WinUI/Contracts/Services/Settings/IPreferencesSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Contracts/Services/Settings/IPreferencesSettingsService.cs
@@ -8,7 +8,7 @@ public interface IPreferencesSettingsService : IBaseObservableSettings
 {
     ObservableCollection<HashSetting> HashSettings { get; }
 
-    Task SaveHashSettingsAsync();
+    void SaveHashSettings();
 
     /// <summary>
     /// 是否启用资源管理器注册的上下文菜单.

--- a/src/DotVast.HashTool.WinUI/Contracts/Services/Settings/IPreferencesSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Contracts/Services/Settings/IPreferencesSettingsService.cs
@@ -8,7 +8,12 @@ public interface IPreferencesSettingsService : IBaseObservableSettings
 {
     ObservableCollection<HashSetting> HashSettings { get; }
 
-    void SaveHashSettings();
+    /// <summary>
+    /// 保存 <see cref="HashSetting"/>
+    /// </summary>
+    /// <param name="hashSetting">要保存的哈希设置.</param>
+    /// <param name="forContextMenu">是否包含对资源管理器上下文菜单的修改.</param>
+    void SaveHashSetting(HashSetting hashSetting, bool forContextMenu = false);
 
     /// <summary>
     /// 是否启用资源管理器注册的上下文菜单.

--- a/src/DotVast.HashTool.WinUI/Models/HashSetting.cs
+++ b/src/DotVast.HashTool.WinUI/Models/HashSetting.cs
@@ -9,7 +9,6 @@ namespace DotVast.HashTool.WinUI.Models;
 
 public sealed partial class HashSetting : ObservableObject
 {
-    private HashKind _kind;
     public HashKind Kind
     {
         get => _kind;
@@ -19,6 +18,7 @@ public sealed partial class HashSetting : ObservableObject
             Name = App.GetService<IHashService>().GetHashData(value).Name;
         }
     }
+    private HashKind _kind;
 
     [JsonIgnore]
     public string Name { get; private set; } = string.Empty;

--- a/src/DotVast.HashTool.WinUI/Services/HashService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/HashService.cs
@@ -15,7 +15,7 @@ internal class HashService : IHashService
         _hashes = dataOptions.Value.Hashes;
     }
 
-    public HashKind[] AllHashes { get; } = Enum.GetValues<HashKind>();
+    public HashKind[] HashKinds { get; } = Enum.GetValues<HashKind>();
 
     public HashKind? GetHash(string hashName)
     {
@@ -50,7 +50,7 @@ internal class HashService : IHashService
     {
         if (hashSettings is null || !hashSettings.Any())
         {
-            return AllHashes.Select(CreateHashSetting);
+            return HashKinds.Select(CreateHashSetting);
         }
 
         return FillNotEmptyHashSettings(hashSettings);
@@ -58,7 +58,7 @@ internal class HashService : IHashService
 
     private IEnumerable<HashSetting> FillNotEmptyHashSettings(IEnumerable<HashSetting> hashSettings)
     {
-        var hashSet = new HashSet<HashKind>(AllHashes.Length);
+        var hashSet = new HashSet<HashKind>(HashKinds.Length);
         foreach (var hashSetting in hashSettings)
         {
             if (hashSet.Add(hashSetting.Kind))
@@ -66,7 +66,7 @@ internal class HashService : IHashService
                 yield return hashSetting!;
             }
         }
-        foreach (var hash in AllHashes)
+        foreach (var hash in HashKinds)
         {
             if (hashSet.Add(hash))
             {
@@ -84,5 +84,26 @@ internal class HashService : IHashService
             IsEnabledForApp = _hashes[hash].IsEnabledForApp,
             IsEnabledForContextMenu = _hashes[hash].IsEnabledForContextMenu,
         };
+    }
+
+    public IEnumerable<HashSetting> MergeHashSettings(IList<HashSetting> hashSettings)
+    {
+        return HashKinds.Select(kind => Merge(kind, hashSettings));
+
+        HashSetting Merge(HashKind defaultHashSettingKind, IList<HashSetting> hashSettings)
+        {
+            var retHashSetting = CreateHashSetting(defaultHashSettingKind);
+            var newHashSetting = hashSettings.FirstOrDefault(x => x.Kind == defaultHashSettingKind);
+            if (newHashSetting is null)
+            {
+                return retHashSetting;
+            }
+
+            retHashSetting.IsChecked = newHashSetting.IsChecked;
+            retHashSetting.IsEnabledForApp = newHashSetting.IsEnabledForApp;
+            retHashSetting.IsEnabledForContextMenu = newHashSetting.IsEnabledForContextMenu;
+
+            return retHashSetting;
+        }
     }
 }

--- a/src/DotVast.HashTool.WinUI/Services/Settings/AppearanceSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/Settings/AppearanceSettingsService.cs
@@ -15,15 +15,16 @@ internal sealed partial class AppearanceSettingsService : BaseObservableSettings
 {
     public override async Task InitializeAsync()
     {
-        _hashFontFamilyName = await LoadAsync(nameof(HashFontFamilyName), DefaultAppearanceSettings.HashFontFamilyName);
-        _isAlwaysOnTop = await LoadAsync(nameof(IsAlwaysOnTop), DefaultAppearanceSettings.IsAlwaysOnTop);
-        _theme = await LoadAsync(nameof(Theme), DefaultAppearanceSettings.Theme);
+        _hashFontFamilyName = Load(nameof(HashFontFamilyName), DefaultAppearanceSettings.HashFontFamilyName);
+        _isAlwaysOnTop = Load(nameof(IsAlwaysOnTop), DefaultAppearanceSettings.IsAlwaysOnTop);
+        _theme = Load(nameof(Theme), DefaultAppearanceSettings.Theme);
 
         Language = string.IsNullOrWhiteSpace(WGAL.PrimaryLanguageOverride)
             ? AppLanguage.System
             : WGAL.PrimaryLanguageOverride.ToAppLanguage();
 
         SetTheme(); // 在初始化时就设置主题
+        await Task.CompletedTask;
     }
 
     public override async Task StartupAsync()
@@ -43,7 +44,7 @@ internal sealed partial class AppearanceSettingsService : BaseObservableSettings
     public string HashFontFamilyName
     {
         get => _hashFontFamilyName;
-        set => SetAndSave(ref _hashFontFamilyName, value);
+        set => SetPropertyAndSave(value, ref _hashFontFamilyName);
     }
     #endregion HashFontFamilyName
 
@@ -52,7 +53,7 @@ internal sealed partial class AppearanceSettingsService : BaseObservableSettings
     public bool IsAlwaysOnTop
     {
         get => _isAlwaysOnTop;
-        set => SetAndSave(ref _isAlwaysOnTop, value, SetIsAlwaysOnTop);
+        set => SetPropertyAndSave(value, ref _isAlwaysOnTop, SetIsAlwaysOnTop);
     }
     private void SetIsAlwaysOnTop()
     {
@@ -65,9 +66,8 @@ internal sealed partial class AppearanceSettingsService : BaseObservableSettings
     public AppTheme Theme
     {
         get => _theme;
-        set => SetAndSave(ref _theme, value, SetTheme);
+        set => SetPropertyAndSave(value, ref _theme, SetTheme);
     }
-
     private void SetTheme()
     {
         //TODO: 等待 Application.Current.RequestedTheme 的动态更改功能, https://github.com/microsoft/microsoft-ui-xaml/issues/4474

--- a/src/DotVast.HashTool.WinUI/Services/Settings/BaseObservableSettings.cs
+++ b/src/DotVast.HashTool.WinUI/Services/Settings/BaseObservableSettings.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 
 using DotVast.HashTool.WinUI.Contracts.Services.Settings;
 
@@ -13,49 +12,44 @@ internal abstract partial class BaseObservableSettings : ObservableObject, IBase
 
     protected readonly ILocalSettingsService _localSettingsService = App.GetService<ILocalSettingsService>();
 
-    protected async Task<T> LoadAsync<T>(string key, T defaultValue)
+    [return: NotNullIfNotNull(nameof(defaultValue))]
+    protected T? Load<T>(string key, T? defaultValue = default)
     {
-        var (hasValue, value) = await _localSettingsService.ReadSettingAsync<T>(key);
-        return hasValue ? (value ?? defaultValue) : defaultValue;
+        return _localSettingsService.ReadSetting(key, defaultValue);
     }
 
-    // TODO: 之后重构该方法
-    protected T Load<T>(string containerName, string key, T defaultValue)
+    [return: NotNullIfNotNull(nameof(defaultValue))]
+    protected T? Load<T>(string containerName, string key, T? defaultValue = default)
     {
-        var containers = Windows.Storage.ApplicationData.Current.LocalSettings.Containers;
-        if (containers.TryGetValue(containerName, out var container) && container.Values.TryGetValue(key, out var obj))
-        {
-            return JsonSerializer.Deserialize<T>((string)obj) ?? defaultValue;
-        }
-        return defaultValue;
+        return _localSettingsService.ReadSetting(containerName, key, defaultValue);
     }
 
-    protected bool SetAndSave<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, [CallerMemberName] string? propertyName = null)
-    {
-        if (SetProperty(ref field, newValue, propertyName) && propertyName != null)
-        {
-            Task.Run(() => _localSettingsService.SaveSettingAsync(propertyName, newValue));
-            return true;
-        }
-        return false;
-    }
-
-    protected bool SetAndSave<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, Action action, [CallerMemberName] string? propertyName = null)
-    {
-        if (SetProperty(ref field, newValue, propertyName) && propertyName != null)
-        {
-            Task.Run(() => _localSettingsService.SaveSettingAsync(propertyName, newValue));
-            action();
-            return true;
-        }
-        return false;
-    }
-
-    protected bool SetAndSave<T>(string containerName, string key, T value, [NotNullIfNotNull(nameof(value))] ref T field, [CallerMemberName] string? propertyName = null)
+    protected bool SetPropertyAndSave<T>(T value, [NotNullIfNotNull(nameof(value))] ref T field, [CallerMemberName] string? propertyName = null)
     {
         if (SetProperty(ref field, value, propertyName) && propertyName != null)
         {
-            Task.Run(() => _localSettingsService.SaveSettingAsync(containerName, key, value));
+            _localSettingsService.SaveSetting(propertyName, value);
+            return true;
+        }
+        return false;
+    }
+
+    protected bool SetPropertyAndSave<T>(string containerName, string key, T value, [NotNullIfNotNull(nameof(value))] ref T field, [CallerMemberName] string? propertyName = null)
+    {
+        if (SetProperty(ref field, value, propertyName) && propertyName != null)
+        {
+            _localSettingsService.SaveSetting(containerName, key, value);
+            return true;
+        }
+        return false;
+    }
+
+    protected bool SetPropertyAndSave<T>(T value, [NotNullIfNotNull(nameof(value))] ref T field, Action action, [CallerMemberName] string? propertyName = null)
+    {
+        if (SetProperty(ref field, value, propertyName) && propertyName != null)
+        {
+            _localSettingsService.SaveSetting(propertyName, value);
+            action();
             return true;
         }
         return false;

--- a/src/DotVast.HashTool.WinUI/Services/Settings/BaseObservableSettings.cs
+++ b/src/DotVast.HashTool.WinUI/Services/Settings/BaseObservableSettings.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 
 using DotVast.HashTool.WinUI.Contracts.Services.Settings;
 
@@ -16,6 +17,17 @@ internal abstract partial class BaseObservableSettings : ObservableObject, IBase
     {
         var (hasValue, value) = await _localSettingsService.ReadSettingAsync<T>(key);
         return hasValue ? (value ?? defaultValue) : defaultValue;
+    }
+
+    // TODO: 之后重构该方法
+    protected T Load<T>(string containerName, string key, T defaultValue)
+    {
+        var containers = Windows.Storage.ApplicationData.Current.LocalSettings.Containers;
+        if (containers.TryGetValue(containerName, out var container) && container.Values.TryGetValue(key, out var obj))
+        {
+            return JsonSerializer.Deserialize<T>((string)obj) ?? defaultValue;
+        }
+        return defaultValue;
     }
 
     protected bool SetAndSave<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, [CallerMemberName] string? propertyName = null)

--- a/src/DotVast.HashTool.WinUI/Services/Settings/PreferencesSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/Settings/PreferencesSettingsService.cs
@@ -18,10 +18,10 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
     public override async Task InitializeAsync()
     {
         await InitializeHashSettings();
-        _fileExplorerContextMenusEnabled = await LoadAsync(nameof(FileExplorerContextMenusEnabled), DefaultPreferencesSettings.FileExplorerContextMenusEnabled);
-        _includePreRelease = await LoadAsync(nameof(IncludePreRelease), DefaultPreferencesSettings.IncludePreRelease);
-        _checkForUpdatesOnStartup = await LoadAsync(nameof(CheckForUpdatesOnStartup), DefaultPreferencesSettings.CheckForUpdatesOnStartup);
-        _startingWhenCreateHashTask = await LoadAsync(nameof(StartingWhenCreateHashTask), DefaultPreferencesSettings.StartingWhenCreateHashTask);
+        _fileExplorerContextMenusEnabled = Load(nameof(FileExplorerContextMenusEnabled), DefaultPreferencesSettings.FileExplorerContextMenusEnabled);
+        _includePreRelease = Load(nameof(IncludePreRelease), DefaultPreferencesSettings.IncludePreRelease);
+        _checkForUpdatesOnStartup = Load(nameof(CheckForUpdatesOnStartup), DefaultPreferencesSettings.CheckForUpdatesOnStartup);
+        _startingWhenCreateHashTask = Load(nameof(StartingWhenCreateHashTask), DefaultPreferencesSettings.StartingWhenCreateHashTask);
     }
 
     public override async Task StartupAsync()
@@ -47,15 +47,15 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
         await Task.CompletedTask;
     }
 
-    public async Task SaveHashSettingsAsync()
+    public void SaveHashSettings()
     {
         foreach (var hashSetting in HashSettings)
         {
-            await _localSettingsService.SaveSettingAsync(SettingsContainerName.DataOptions_Hashes, hashSetting.Kind.ToString(), hashSetting);
+            _localSettingsService.SaveSetting(SettingsContainerName.DataOptions_Hashes, hashSetting.Kind.ToString(), hashSetting);
         }
 
         var hashNamesForContexMenu = HashSettings.Where(h => h.IsEnabledForContextMenu).Select(h => h.Name);
-        await _localSettingsService.SaveSettingAsync(SettingsContainerName.ContextMenu, "HashNames", hashNamesForContexMenu);
+        _localSettingsService.SaveSetting(SettingsContainerName.ContextMenu, "HashNames", hashNamesForContexMenu);
     }
     #endregion HashSettings
 
@@ -64,7 +64,7 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
     public bool FileExplorerContextMenusEnabled
     {
         get => _fileExplorerContextMenusEnabled;
-        set => SetAndSave("ContextMenu", "IsEnabled", value, ref _fileExplorerContextMenusEnabled);
+        set => SetPropertyAndSave(SettingsContainerName.ContextMenu, "IsEnabled", value, ref _fileExplorerContextMenusEnabled);
     }
     #endregion FileExplorerContextMenusEnabled
 
@@ -73,7 +73,7 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
     public bool IncludePreRelease
     {
         get => _includePreRelease;
-        set => SetAndSave(ref _includePreRelease, value);
+        set => SetPropertyAndSave(value, ref _includePreRelease);
     }
     #endregion IncludePreRelease
 
@@ -82,7 +82,7 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
     public bool CheckForUpdatesOnStartup
     {
         get => _checkForUpdatesOnStartup;
-        set => SetAndSave(ref _checkForUpdatesOnStartup, value);
+        set => SetPropertyAndSave(value, ref _checkForUpdatesOnStartup);
     }
     #endregion CheckForUpdatesOnStartup
 
@@ -91,7 +91,7 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
     public bool StartingWhenCreateHashTask
     {
         get => _startingWhenCreateHashTask;
-        set => SetAndSave(ref _startingWhenCreateHashTask, value);
+        set => SetPropertyAndSave(value, ref _startingWhenCreateHashTask);
     }
     #endregion
 }

--- a/src/DotVast.HashTool.WinUI/Services/Settings/PreferencesSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/Settings/PreferencesSettingsService.cs
@@ -47,13 +47,18 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
         await Task.CompletedTask;
     }
 
-    public void SaveHashSettings()
+    public void SaveHashSetting(HashSetting hashSetting, bool forContextMenu = false)
     {
-        foreach (var hashSetting in HashSettings)
-        {
-            _localSettingsService.SaveSetting(SettingsContainerName.DataOptions_Hashes, hashSetting.Kind.ToString(), hashSetting);
-        }
+        _localSettingsService.SaveSetting(SettingsContainerName.DataOptions_Hashes, hashSetting.Kind.ToString(), hashSetting);
 
+        if (forContextMenu)
+        {
+            SaveHashNamesForContextMenu();
+        }
+    }
+
+    private void SaveHashNamesForContextMenu()
+    {
         var hashNamesForContexMenu = HashSettings.Where(h => h.IsEnabledForContextMenu).Select(h => h.Name);
         _localSettingsService.SaveSetting(SettingsContainerName.ContextMenu, "HashNames", hashNamesForContexMenu);
     }

--- a/src/DotVast.HashTool.WinUI/ViewModels/HashSettingsViewModel.cs
+++ b/src/DotVast.HashTool.WinUI/ViewModels/HashSettingsViewModel.cs
@@ -22,20 +22,20 @@ public partial class HashSettingsViewModel : ObservableRecipient, IViewModel, IN
 
     protected override void OnActivated()
     {
-        Messenger.Register<HashSettingsViewModel, HashSettingIsEnabledForAppChangedMessage>(this, async (r, m) =>
+        Messenger.Register<HashSettingsViewModel, HashSettingIsEnabledForAppChangedMessage>(this, (r, m) =>
         {
             Debug.WriteLine($"[{DateTime.Now}] HashOptionSettingsViewModel.Messenger > HashSettingIsEnabledForAppChangedMessage");
             Debug.WriteLine($"Hash.Name: {m.HashSetting.Kind}");
             Debug.WriteLine($"IsEnabled: {m.IsEnabledForApp}");
-            await _preferencesSettingsService.SaveHashSettingsAsync();
+            _preferencesSettingsService.SaveHashSettings();
         });
 
-        Messenger.Register<HashSettingsViewModel, HashSettingIsEnabledForContextMenuChangedMessage>(this, async (r, m) =>
+        Messenger.Register<HashSettingsViewModel, HashSettingIsEnabledForContextMenuChangedMessage>(this, (r, m) =>
         {
             Debug.WriteLine($"[{DateTime.Now}] HashOptionSettingsViewModel.Messenger > HashSettingIsEnabledForContextMenuChangedMessage");
             Debug.WriteLine($"Hash.Name: {m.HashSetting.Kind}");
             Debug.WriteLine($"IsEnabled: {m.IsEnabledForContextMenu}");
-            await _preferencesSettingsService.SaveHashSettingsAsync();
+            _preferencesSettingsService.SaveHashSettings();
         });
     }
 
@@ -62,7 +62,7 @@ public partial class HashSettingsViewModel : ObservableRecipient, IViewModel, IN
         if (sender is ObservableCollection<HashSetting>
             && e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add)
         {
-            _preferencesSettingsService.SaveHashSettingsAsync();
+            _preferencesSettingsService.SaveHashSettings();
         }
     }
 }

--- a/src/DotVast.HashTool.WinUI/ViewModels/HashSettingsViewModel.cs
+++ b/src/DotVast.HashTool.WinUI/ViewModels/HashSettingsViewModel.cs
@@ -27,7 +27,7 @@ public partial class HashSettingsViewModel : ObservableRecipient, IViewModel, IN
             Debug.WriteLine($"[{DateTime.Now}] HashOptionSettingsViewModel.Messenger > HashSettingIsEnabledForAppChangedMessage");
             Debug.WriteLine($"Hash.Name: {m.HashSetting.Kind}");
             Debug.WriteLine($"IsEnabled: {m.IsEnabledForApp}");
-            _preferencesSettingsService.SaveHashSettings();
+            _preferencesSettingsService.SaveHashSetting(m.HashSetting);
         });
 
         Messenger.Register<HashSettingsViewModel, HashSettingIsEnabledForContextMenuChangedMessage>(this, (r, m) =>
@@ -35,7 +35,7 @@ public partial class HashSettingsViewModel : ObservableRecipient, IViewModel, IN
             Debug.WriteLine($"[{DateTime.Now}] HashOptionSettingsViewModel.Messenger > HashSettingIsEnabledForContextMenuChangedMessage");
             Debug.WriteLine($"Hash.Name: {m.HashSetting.Kind}");
             Debug.WriteLine($"IsEnabled: {m.IsEnabledForContextMenu}");
-            _preferencesSettingsService.SaveHashSettings();
+            _preferencesSettingsService.SaveHashSetting(m.HashSetting, true);
         });
     }
 
@@ -46,23 +46,12 @@ public partial class HashSettingsViewModel : ObservableRecipient, IViewModel, IN
     void INavigationAware.OnNavigatedTo(object? parameter)
     {
         IsActive = true;
-        HashSettings.CollectionChanged += HashOptions_CollectionChanged;
     }
 
     void INavigationAware.OnNavigatedFrom()
     {
         IsActive = false;
-        HashSettings.CollectionChanged -= HashOptions_CollectionChanged;
     }
 
     #endregion INavigationAware
-
-    private void HashOptions_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-    {
-        if (sender is ObservableCollection<HashSetting>
-            && e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add)
-        {
-            _preferencesSettingsService.SaveHashSettings();
-        }
-    }
 }

--- a/src/DotVast.HashTool.WinUI/ViewModels/HomeViewModel.cs
+++ b/src/DotVast.HashTool.WinUI/ViewModels/HomeViewModel.cs
@@ -71,12 +71,12 @@ public sealed partial class HomeViewModel : ObservableRecipient, IViewModel, INa
             });
         });
 
-        Messenger.Register<HomeViewModel, HashSettingIsCheckedChangedMessage>(this, async (r, m) =>
+        Messenger.Register<HomeViewModel, HashSettingIsCheckedChangedMessage>(this, (r, m) =>
         {
             Debug.WriteLine($"[{DateTime.Now}] HomeViewModel.Messenger > HashSettingIsCheckedChangedMessage");
             Debug.WriteLine($"Hash.Name: {m.HashSetting.Kind}");
             Debug.WriteLine($"IsChecked: {m.IsChecked}");
-            await _preferencesSettingsService.SaveHashSettingsAsync();
+            _preferencesSettingsService.SaveHashSettings();
             CreateTaskCommand.NotifyCanExecuteChanged();
         });
 

--- a/src/DotVast.HashTool.WinUI/ViewModels/HomeViewModel.cs
+++ b/src/DotVast.HashTool.WinUI/ViewModels/HomeViewModel.cs
@@ -76,7 +76,7 @@ public sealed partial class HomeViewModel : ObservableRecipient, IViewModel, INa
             Debug.WriteLine($"[{DateTime.Now}] HomeViewModel.Messenger > HashSettingIsCheckedChangedMessage");
             Debug.WriteLine($"Hash.Name: {m.HashSetting.Kind}");
             Debug.WriteLine($"IsChecked: {m.IsChecked}");
-            _preferencesSettingsService.SaveHashSettings();
+            _preferencesSettingsService.SaveHashSetting(m.HashSetting);
             CreateTaskCommand.NotifyCanExecuteChanged();
         });
 

--- a/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml
+++ b/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml
@@ -41,8 +41,6 @@
                 Grid.Row="1"
                 Margin="-8,0"
                 Padding="0,-4"
-                AllowDrop="True"
-                CanReorderItems="True"
                 ItemTemplate="{StaticResource HashSettingDataTemplate}"
                 ItemsSource="{x:Bind ViewModel.HashSettings}"
                 SelectionMode="None"


### PR DESCRIPTION
## Summary

由于本地设置单个值限制为 8K bytes，而当前哈希设置在序列化后可以达到 4K，考虑到容量限制以及每次序列化时对所有哈希设置都进行序列化保存，所以将哈希设置改为容器储存，其中将 `HashKind` 作为键，`HashSetting` 作为值。

## Detail / Remark

- 不包含破坏性更改，但会造成之前相关哈希设置的丢失。
- 移除了对哈希拖放排序的支持。
- 本地设置保存时采用同步方法。
- 容器名称为 `DataOptions:Hashes`，和 appsettings.json 的读取方式保持一致。
- 现在在保存哈希设置时是单独保存的，效率更高。
- 现在的哈希设置读取方式是：读取 appsettings.json 内的默认数据，再读取本地设置内的数据对默认数据进行覆盖。

## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Related:** #xxx
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Documentation updated:** if relevant, docs or wiki should updated
