### PR TITLE
feat: 支持选择哈希输出格式

### DIFF
--- a/src/DotVast.HashTool.WinUI.Core/Helpers/Converter.cs
+++ b/src/DotVast.HashTool.WinUI.Core/Helpers/Converter.cs
@@ -1,0 +1,29 @@
+using System.Runtime.CompilerServices;
+
+namespace DotVast.HashTool.WinUI.Core.Helpers;
+
+public static class Converter
+{
+    private const string LowerHexChars = "0123456789abcdef";
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string ToLowerHexString(byte[] bytes)
+    {
+        return ToLowerHexString(bytes.AsSpan());
+    }
+
+    public static string ToLowerHexString(ReadOnlySpan<byte> bytes)
+    {
+        Span<char> result = bytes.Length > 64
+            ? new char[bytes.Length * 2].AsSpan()
+            : stackalloc char[bytes.Length * 2];
+
+        int index = 0;
+        foreach (var b in bytes)
+        {
+            result[index++] = LowerHexChars[b >> 4];
+            result[index++] = LowerHexChars[b & 0xF];
+        }
+        return new string(result);
+    }
+}

--- a/src/DotVast.HashTool.WinUI/Contracts/Services/IHashService.cs
+++ b/src/DotVast.HashTool.WinUI/Contracts/Services/IHashService.cs
@@ -7,11 +7,11 @@ public interface IHashService
 {
     IReadOnlyList<HashKind> HashKinds { get; }
 
+    string GetName(HashKind hashKind);
+
     HashKind? GetHash(string hashName);
 
     HashKind[] GetHashes(IEnumerable<string> hashNames);
-
-    HashData GetHashData(HashKind hash);
 
     /// <summary>
     /// 获取合并后的哈希设置.

--- a/src/DotVast.HashTool.WinUI/Controls/HashTaskGrid.xaml.cs
+++ b/src/DotVast.HashTool.WinUI/Controls/HashTaskGrid.xaml.cs
@@ -116,7 +116,7 @@ public sealed partial class HashTaskGrid : UserControl
         sb.Append(ItemSeparator);
         sb.Append(hashTask.DateTime.ToString("HH:mm:ss"));
         sb.Append(ItemSeparator);
-        sb.AppendJoin(HashSeparator, hashTask.SelectedHashKinds.Select(kind => kind.ToHashData().Name));
+        sb.AppendJoin(HashSeparator, hashTask.SelectedHashKinds.Select(kind => kind.ToName()));
         return sb.ToString();
     }
 

--- a/src/DotVast.HashTool.WinUI/Enums/HashFormat.cs
+++ b/src/DotVast.HashTool.WinUI/Enums/HashFormat.cs
@@ -1,10 +1,14 @@
+using System.Text.Json.Serialization;
+
 namespace DotVast.HashTool.WinUI.Enums;
 
 /// <summary>
 /// 哈希结果的表示格式.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum HashFormat
 {
-    Base16,
+    Base16Upper,
+    Base16Lower,
     Base64,
 }

--- a/src/DotVast.HashTool.WinUI/Enums/HashFormat.cs
+++ b/src/DotVast.HashTool.WinUI/Enums/HashFormat.cs
@@ -12,3 +12,18 @@ public enum HashFormat
     Base16Lower,
     Base64,
 }
+
+internal static class HashFormatExtensions
+{
+    // Don't translate this.
+    public static string ToDisplay(HashFormat hashFormat)
+    {
+        return hashFormat switch
+        {
+            HashFormat.Base16Upper => "Hex Upper",
+            HashFormat.Base16Lower => "Hex Lower",
+            HashFormat.Base64 => "Base64",
+            _ => throw new ArgumentOutOfRangeException(nameof(hashFormat)),
+        };
+    }
+}

--- a/src/DotVast.HashTool.WinUI/Enums/HashKind.cs
+++ b/src/DotVast.HashTool.WinUI/Enums/HashKind.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text.Json.Serialization;
 
+using DotVast.HashTool.WinUI.Contracts.Services.Settings;
 using DotVast.HashTool.WinUI.Helpers.Hashes;
 
 using DotVast.HashTool.WinUI.Models;
@@ -58,6 +59,14 @@ public enum HashKind
 
 internal static class HashKindExtensions
 {
+    private static IHashService? s_hashService;
+    private static IHashService s_HashService =>
+        s_hashService ??= App.GetService<IHashService>();
+
+    private static IReadOnlyList<HashSetting>? s_hashSettings;
+    private static IReadOnlyList<HashSetting> s_HashSettings =>
+        s_hashSettings ??= App.GetService<IPreferencesSettingsService>().HashSettings;
+
     public static HashAlgorithm ToHashAlgorithm(this HashKind hashKind)
     {
         return hashKind switch
@@ -107,8 +116,13 @@ internal static class HashKindExtensions
         };
     }
 
-    public static HashData ToHashData(this HashKind hashKind)
+    public static string ToName(this HashKind hashKind)
     {
-        return App.GetService<IHashService>().GetHashData(hashKind);
+        return s_HashService.GetName(hashKind);
+    }
+
+    public static HashSetting GetHashSetting(this HashKind hashKind)
+    {
+        return s_HashSettings.First(hs => hs.Kind == hashKind);
     }
 }

--- a/src/DotVast.HashTool.WinUI/Enums/HashKind.cs
+++ b/src/DotVast.HashTool.WinUI/Enums/HashKind.cs
@@ -63,9 +63,9 @@ internal static class HashKindExtensions
     private static IHashService s_HashService =>
         s_hashService ??= App.GetService<IHashService>();
 
-    private static IReadOnlyList<HashSetting>? s_hashSettings;
-    private static IReadOnlyList<HashSetting> s_HashSettings =>
-        s_hashSettings ??= App.GetService<IPreferencesSettingsService>().HashSettings;
+    private static IReadOnlyDictionary<HashKind, HashSetting>? s_hashSettings;
+    private static IReadOnlyDictionary<HashKind, HashSetting> s_HashSettings =>
+        s_hashSettings ??= App.GetService<IPreferencesSettingsService>().HashSettings.ToDictionary(hs => hs.Kind);
 
     public static HashAlgorithm ToHashAlgorithm(this HashKind hashKind)
     {
@@ -123,6 +123,6 @@ internal static class HashKindExtensions
 
     public static HashSetting GetHashSetting(this HashKind hashKind)
     {
-        return s_HashSettings.First(hs => hs.Kind == hashKind);
+        return s_HashSettings[hashKind];
     }
 }

--- a/src/DotVast.HashTool.WinUI/Enums/MessageToken.cs
+++ b/src/DotVast.HashTool.WinUI/Enums/MessageToken.cs
@@ -6,6 +6,7 @@ internal enum MessageToken
 
     IComputeHashService_FileNotFound,
 
+    HashSetting_Format,
     HashSetting_IsChecked,
     HashSetting_IsEnabledForApp,
     HashSetting_IsEnabledForContextMenu,

--- a/src/DotVast.HashTool.WinUI/MainWindow.xaml
+++ b/src/DotVast.HashTool.WinUI/MainWindow.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:windowex="using:WinUIEx"
-    Width="800"
-    Height="520"
+    Width="840"
+    Height="540"
     MinWidth="500"
     MinHeight="300"
     PersistenceId="MainWindow">

--- a/src/DotVast.HashTool.WinUI/Models/DataOptions.cs
+++ b/src/DotVast.HashTool.WinUI/Models/DataOptions.cs
@@ -11,7 +11,7 @@ public class HashData
 {
     public string Name { get; set; } = string.Empty;
     public string[] Alias { get; set; } = Array.Empty<string>();
-    public HashFormat Format { get; set; } = HashFormat.Base16;
+    public HashFormat Format { get; set; } = HashFormat.Base16Upper;
     public bool IsChecked { get; set; }
     public bool IsEnabledForApp { get; set; }
     public bool IsEnabledForContextMenu { get; set; }

--- a/src/DotVast.HashTool.WinUI/Models/HashResult.cs
+++ b/src/DotVast.HashTool.WinUI/Models/HashResult.cs
@@ -19,9 +19,11 @@ public sealed class HashResult
 
 public readonly record struct HashResultItem(HashKind Kind, string Value)
 {
+    private readonly HashSetting _hashSetting = Kind.GetHashSetting();
+
     /// <summary>
-    /// 名称. 仅用作界面显示, 不要用于内部调用.
+    /// 名称.
     /// </summary>
     [JsonIgnore]
-    public string Name { get; } = Kind.ToName();
+    public string Name => _hashSetting.Name;
 }

--- a/src/DotVast.HashTool.WinUI/Models/HashResult.cs
+++ b/src/DotVast.HashTool.WinUI/Models/HashResult.cs
@@ -19,6 +19,9 @@ public sealed class HashResult
 
 public readonly record struct HashResultItem(HashKind Kind, string Value)
 {
+    /// <summary>
+    /// 名称. 仅用作界面显示, 不要用于内部调用.
+    /// </summary>
     [JsonIgnore]
-    public string Name { get; } = Kind.ToHashData().Name;
+    public string Name { get; } = Kind.ToName();
 }

--- a/src/DotVast.HashTool.WinUI/Models/HashSetting.cs
+++ b/src/DotVast.HashTool.WinUI/Models/HashSetting.cs
@@ -14,13 +14,22 @@ public sealed partial class HashSetting : ObservableObject
         init
         {
             _kind = value;
-            Name = App.GetService<IHashService>().GetHashData(value).Name;
+            Name = _kind.ToName();
         }
     }
     private HashKind _kind;
 
+    /// <summary>
+    /// 名称. 仅用作界面显示, 不要用于内部调用.
+    /// </summary>
     [JsonIgnore]
     public string Name { get; private set; } = string.Empty;
+
+    [ObservableProperty]
+    private HashFormat _format;
+
+    partial void OnFormatChanged(HashFormat value) =>
+        WeakReferenceMessenger.Default.SendV<HashSetting, HashFormat>(new(this, value), EMT.HashSetting_Format);
 
     /// <summary>
     /// 是否选择该项.

--- a/src/DotVast.HashTool.WinUI/Models/HashSetting.cs
+++ b/src/DotVast.HashTool.WinUI/Models/HashSetting.cs
@@ -20,7 +20,7 @@ public sealed partial class HashSetting : ObservableObject
     private HashKind _kind;
 
     /// <summary>
-    /// 名称. 仅用作界面显示, 不要用于内部调用.
+    /// 名称. 用作界面显示, 尽可能避免内部调用.
     /// </summary>
     [JsonIgnore]
     public string Name { get; private set; } = string.Empty;

--- a/src/DotVast.HashTool.WinUI/Services/ActivationService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/ActivationService.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
 
+using WinUIEx;
+
 namespace DotVast.HashTool.WinUI.Services;
 
 public sealed class ActivationService : IActivationService
@@ -46,6 +48,8 @@ public sealed class ActivationService : IActivationService
 
         // Handle activation via ActivationHandlers.
         await HandleActivationAsync(activationArgs);
+
+        App.MainWindow.CenterOnScreen();
 
         // Activate the MainWindow.
         App.MainWindow.Activate();

--- a/src/DotVast.HashTool.WinUI/Services/ComputeHashService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/ComputeHashService.cs
@@ -286,26 +286,13 @@ internal sealed class ComputeHashService : IComputeHashService
 
     private string GetFormattedHash(byte[] hashData, HashKind kind)
     {
-        return kind.ToHashData().Format switch
+        return kind.GetHashSetting().Format switch
         {
             HashFormat.Base16Upper => Convert.ToHexString(hashData),
-            HashFormat.Base16Lower => ToHexLowerString(hashData),
+            HashFormat.Base16Lower => Core.Helpers.Converter.ToLowerHexString(hashData),
             HashFormat.Base64 => Convert.ToBase64String(hashData),
             _ => throw new ArgumentOutOfRangeException(nameof(kind), $"The HashKind {kind} is out of range and cannot be processed."),
         };
-    }
-
-    private static string ToHexLowerString(byte[] bytes)
-    {
-        const string LowerHex = "0123456789abcdef";
-        Span<char> result = stackalloc char[bytes.Length * 2];
-        int index = 0;
-        foreach (var b in bytes)
-        {
-            result[index++] = LowerHex[b >> 4];
-            result[index++] = LowerHex[b & 0xF];
-        }
-        return new string(result);
     }
 
     private struct ProgressRateLimiter

--- a/src/DotVast.HashTool.WinUI/Services/ComputeHashService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/ComputeHashService.cs
@@ -288,10 +288,24 @@ internal sealed class ComputeHashService : IComputeHashService
     {
         return kind.ToHashData().Format switch
         {
-            HashFormat.Base16 => Convert.ToHexString(hashData),
+            HashFormat.Base16Upper => Convert.ToHexString(hashData),
+            HashFormat.Base16Lower => ToHexLowerString(hashData),
             HashFormat.Base64 => Convert.ToBase64String(hashData),
             _ => throw new ArgumentOutOfRangeException(nameof(kind), $"The HashKind {kind} is out of range and cannot be processed."),
         };
+    }
+
+    private static string ToHexLowerString(byte[] bytes)
+    {
+        const string LowerHex = "0123456789abcdef";
+        Span<char> result = stackalloc char[bytes.Length * 2];
+        int index = 0;
+        foreach (var b in bytes)
+        {
+            result[index++] = LowerHex[b >> 4];
+            result[index++] = LowerHex[b & 0xF];
+        }
+        return new string(result);
     }
 
     private struct ProgressRateLimiter

--- a/src/DotVast.HashTool.WinUI/Services/HashService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/HashService.cs
@@ -15,6 +15,11 @@ internal class HashService : IHashService
         _hashes = dataOptions.Value.Hashes;
     }
 
+    public string GetName(HashKind hashKind)
+    {
+        return _hashes[hashKind].Name;
+    }
+
     public IReadOnlyList<HashKind> HashKinds { get; } = Enum.GetValues<HashKind>();
 
     public HashKind? GetHash(string hashName)
@@ -41,23 +46,20 @@ internal class HashService : IHashService
         return hashNames.Select(GetHash).OfType<HashKind>().ToArray();
     }
 
-    public HashData GetHashData(HashKind hash)
-    {
-        return _hashes[hash];
-    }
-
     public IEnumerable<HashSetting> GetMergedHashSettings(IList<HashSetting> hashSettings)
     {
         return HashKinds.Select(kind => Merge(kind, hashSettings));
 
         HashSetting Merge(HashKind defaultHashSettingKind, IList<HashSetting> hashSettings)
         {
+            var defaultHashSetting = _hashes[defaultHashSettingKind];
             var retHashSetting = new HashSetting()
             {
                 Kind = defaultHashSettingKind,
-                IsChecked = _hashes[defaultHashSettingKind].IsChecked,
-                IsEnabledForApp = _hashes[defaultHashSettingKind].IsEnabledForApp,
-                IsEnabledForContextMenu = _hashes[defaultHashSettingKind].IsEnabledForContextMenu,
+                Format = defaultHashSetting.Format,
+                IsChecked = defaultHashSetting.IsChecked,
+                IsEnabledForApp = defaultHashSetting.IsEnabledForApp,
+                IsEnabledForContextMenu = defaultHashSetting.IsEnabledForContextMenu,
             };
 
             var newHashSetting = hashSettings.FirstOrDefault(x => x.Kind == defaultHashSettingKind);
@@ -66,6 +68,7 @@ internal class HashService : IHashService
                 return retHashSetting;
             }
 
+            retHashSetting.Format = newHashSetting.Format;
             retHashSetting.IsChecked = newHashSetting.IsChecked;
             retHashSetting.IsEnabledForApp = newHashSetting.IsEnabledForApp;
             retHashSetting.IsEnabledForContextMenu = newHashSetting.IsEnabledForContextMenu;

--- a/src/DotVast.HashTool.WinUI/Strings/en-US/Resources.resw
+++ b/src/DotVast.HashTool.WinUI/Strings/en-US/Resources.resw
@@ -13,7 +13,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppDescription" xml:space="preserve">
-    <value>A Tool for Calculating the Hash Value of Any File, Folder, or Text!</value>
+    <value>A tool for calculating hash values of files or folders!</value>
   </data>
   <data name="AppDisplayName" xml:space="preserve">
     <value>HashTool</value>
@@ -31,10 +31,10 @@
     <value>Save (Ctrl+S)</value>
   </data>
   <data name="HashSettingsPage_ItemDescription.Message" xml:space="preserve">
-    <value>Hash name, Enabled in the APP, Enabled in the explorer context menu.</value>
+    <value>Hash name | Enabled in APP | Enabled in explorer context menu | Hash output format.</value>
   </data>
   <data name="HashSettingsPage_ItemDescription.Title" xml:space="preserve">
-    <value>The Content of the Item Is Expressed From Left to Right</value>
+    <value>The item content is expressed from left to right</value>
   </data>
   <data name="HashSettingsPage_Title" xml:space="preserve">
     <value>Hash Settings</value>
@@ -112,7 +112,7 @@
     <value>Include Pre-Release</value>
   </data>
   <data name="SettingsPage_Language.Description" xml:space="preserve">
-    <value>Change the theme displayed in the APP</value>
+    <value>Change the language displayed in the APP</value>
   </data>
   <data name="SettingsPage_Language.Header" xml:space="preserve">
     <value>Language</value>
@@ -139,7 +139,7 @@
     <value>https://github.com/KiyanYang/DotVast.HashTool.WinUI</value>
   </data>
   <data name="SettingsPage_Theme.Description" xml:space="preserve">
-    <value>Change the language displayed in the APP</value>
+    <value>Change the theme displayed in the APP</value>
   </data>
   <data name="SettingsPage_Theme.Header" xml:space="preserve">
     <value>Theme</value>

--- a/src/DotVast.HashTool.WinUI/Strings/zh-Hans/Resources.resw
+++ b/src/DotVast.HashTool.WinUI/Strings/zh-Hans/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppDescription" xml:space="preserve">
-    <value>用于计算文件、文件夹或文本哈希值的工具！</value>
+    <value>用于计算文件或文件夹哈希值的工具！</value>
   </data>
   <data name="AppDisplayName" xml:space="preserve">
     <value>HashTool</value>
@@ -139,7 +139,7 @@
     <comment>保存; 快捷键 Ctrl+S</comment>
   </data>
   <data name="HashSettingsPage_ItemDescription.Message" xml:space="preserve">
-    <value>哈希名称，在软件内启用，在资源管理器菜单内启用。</value>
+    <value>哈希名称 | 在软件内启用 | 在资源管理器菜单内启用 | 哈希输出格式。</value>
   </data>
   <data name="HashSettingsPage_ItemDescription.Title" xml:space="preserve">
     <value>条目内容从左至右依次表示</value>

--- a/src/DotVast.HashTool.WinUI/ViewModels/HashSettingsViewModel.cs
+++ b/src/DotVast.HashTool.WinUI/ViewModels/HashSettingsViewModel.cs
@@ -1,4 +1,5 @@
 using DotVast.HashTool.WinUI.Contracts.Services.Settings;
+using DotVast.HashTool.WinUI.Enums;
 using DotVast.HashTool.WinUI.Helpers;
 using DotVast.HashTool.WinUI.Models;
 
@@ -15,10 +16,17 @@ public partial class HashSettingsViewModel : ObservableRecipient, IViewModel, IN
 
     public IReadOnlyList<HashSetting> HashSettings => _preferencesSettingsService.HashSettings;
 
+    public IReadOnlyList<HashFormat> HashFormats { get; } = Enum.GetValues<HashFormat>();
+
     #region Messenger
 
     protected override void OnActivated()
     {
+        Messenger.RegisterV<HashSettingsViewModel, HashSetting, HashFormat>(this, EMT.HashSetting_Format, static (r, o, _) =>
+        {
+            r._preferencesSettingsService.SaveHashSetting(o);
+        });
+
         Messenger.RegisterV<HashSettingsViewModel, HashSetting, bool>(this, EMT.HashSetting_IsEnabledForApp, static (r, o, _) =>
         {
             r._preferencesSettingsService.SaveHashSetting(o);

--- a/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml
+++ b/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml
@@ -40,7 +40,7 @@
             </Grid.RowDefinitions>
             <InfoBar
                 x:Uid="HashSettingsPage_ItemDescription"
-                Margin="0,0,0,16"
+                Margin="0,0,0,12"
                 IsClosable="False"
                 IsOpen="True" />
             <ItemsRepeater

--- a/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml
+++ b/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:DotVast.HashTool.WinUI.Controls"
+    xmlns:enums="using:DotVast.HashTool.WinUI.Enums"
     xmlns:models="using:DotVast.HashTool.WinUI.Models">
 
     <Page.Resources>
@@ -12,7 +13,7 @@
                     <ColumnDefinition Width="*" MinWidth="88" />
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="136" />
+                    <ColumnDefinition Width="116" />
                 </Grid.ColumnDefinitions>
                 <TextBlock VerticalAlignment="Center" Text="{x:Bind Name}" />
                 <CheckBox
@@ -27,7 +28,13 @@
                     Grid.Column="3"
                     HorizontalAlignment="Stretch"
                     ItemsSource="{StaticResource HashFormats}"
-                    SelectedItem="{x:Bind Format, Mode=TwoWay}" />
+                    SelectedItem="{x:Bind Format, Mode=TwoWay}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="enums:HashFormat">
+                            <TextBlock Text="{x:Bind enums:HashFormatExtensions.ToDisplay((enums:HashFormat))}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
             </Grid>
         </DataTemplate>
     </Page.Resources>

--- a/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml
+++ b/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml
@@ -7,11 +7,12 @@
 
     <Page.Resources>
         <DataTemplate x:Key="HashSettingDataTemplate" x:DataType="models:HashSetting">
-            <Grid ColumnSpacing="12" Style="{StaticResource CardGridStyle}">
+            <Grid ColumnSpacing="6" Style="{StaticResource CardGridStyle}">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" MinWidth="88" />
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="136" />
                 </Grid.ColumnDefinitions>
                 <TextBlock VerticalAlignment="Center" Text="{x:Bind Name}" />
                 <CheckBox
@@ -22,6 +23,11 @@
                     Grid.Column="2"
                     MinWidth="0"
                     IsChecked="{x:Bind IsEnabledForContextMenu, Mode=TwoWay}" />
+                <ComboBox
+                    Grid.Column="3"
+                    HorizontalAlignment="Stretch"
+                    ItemsSource="{StaticResource HashFormats}"
+                    SelectedItem="{x:Bind Format, Mode=TwoWay}" />
             </Grid>
         </DataTemplate>
     </Page.Resources>
@@ -37,31 +43,17 @@
                 Margin="0,0,0,16"
                 IsClosable="False"
                 IsOpen="True" />
-            <GridView
+            <ItemsRepeater
                 Grid.Row="1"
-                Margin="-8,0"
-                Padding="0,-4"
                 ItemTemplate="{StaticResource HashSettingDataTemplate}"
-                ItemsSource="{x:Bind ViewModel.HashSettings}"
-                SelectionMode="None"
-                SizeChanged="GridView_SizeChanged">
-                <GridView.ItemContainerStyle>
-                    <Style TargetType="GridViewItem">
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                        <Setter Property="Margin" Value="8,4" />
-                    </Style>
-                </GridView.ItemContainerStyle>
-                <GridView.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <ItemsWrapGrid Orientation="Horizontal" />
-                    </ItemsPanelTemplate>
-                </GridView.ItemsPanel>
-                <GridView.ItemContainerTransitions>
-                    <TransitionCollection>
-                        <RepositionThemeTransition IsStaggeringEnabled="False" />
-                    </TransitionCollection>
-                </GridView.ItemContainerTransitions>
-            </GridView>
+                ItemsSource="{x:Bind ViewModel.HashSettings}">
+                <ItemsRepeater.Layout>
+                    <UniformGridLayout
+                        ItemsStretch="Fill"
+                        MinColumnSpacing="12"
+                        MinRowSpacing="8" />
+                </ItemsRepeater.Layout>
+            </ItemsRepeater>
         </Grid>
     </controls:NavigationViewBodyScrollViewer>
 

--- a/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml.cs
+++ b/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml.cs
@@ -7,8 +7,6 @@ namespace DotVast.HashTool.WinUI.Views;
 
 public sealed partial class HashSettingsPage : Page, IView
 {
-    private const double HashOptionGridViewItemMinWidth = 240;
-
     public HashSettingsViewModel ViewModel { get; }
 
     IViewModel IView.ViewModel => ViewModel;
@@ -19,14 +17,5 @@ public sealed partial class HashSettingsPage : Page, IView
         Resources.AddByExpression(() => ViewModel.HashFormats);
         InitializeComponent();
         NavigationViewHeaderBehavior.SetHeaderContext(this, Localization.HashSettingsPage_Title);
-    }
-
-    private void GridView_SizeChanged(object sender, Microsoft.UI.Xaml.SizeChangedEventArgs e)
-    {
-        if (e.NewSize.Width != e.PreviousSize.Width && sender is GridView { ItemsPanelRoot: ItemsWrapGrid itemsWrapGrid })
-        {
-            var columns = Math.Floor(e.NewSize.Width / HashOptionGridViewItemMinWidth);
-            itemsWrapGrid.ItemWidth = e.NewSize.Width / columns;
-        }
     }
 }

--- a/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml.cs
+++ b/src/DotVast.HashTool.WinUI/Views/HashSettingsPage.xaml.cs
@@ -16,6 +16,7 @@ public sealed partial class HashSettingsPage : Page, IView
     public HashSettingsPage()
     {
         ViewModel = App.GetService<HashSettingsViewModel>();
+        Resources.AddByExpression(() => ViewModel.HashFormats);
         InitializeComponent();
         NavigationViewHeaderBehavior.SetHeaderContext(this, Localization.HashSettingsPage_Title);
     }


### PR DESCRIPTION
## Summary

支持选择哈希输出格式。

## Detail / Remark

哈希算法往往以 `byte[]` 作为输出，但在可读性和数据交换上考虑，一般会采用 Hex 来表示输出。但是也有一些算法如 QuickXor 算法偏向以 Base64 作为输出。同时还有一些数据验证如 SRI 采用 SHA-256 等算法，但是输出格式却是 Base64，因此提供选项以支持自定义输出。

当前的输出格式支持如下（Base16Upper 作为默认值）：

```cs
public enum HashFormat
{
    Base16Upper,
    Base16Lower,
    Base64,
}
```

**注意：输出格式不会应用于已计算的结果。例如在计算文件夹的过程中调整了输出格式，那么已计算的结果依旧保持原来的格式，新计算的结果则采用新的输出格式。**

不即时刷新所有输出格式出于以下考虑：

- 如果输出结果持有 `byte[]`，在导出或呈现时再进行格式化输出，得益于虚拟化技术，这在显示结果时对于性能几乎没有影响。但是这对筛选的影响非常大，因为筛选是以字符串做匹配，因此在数据量大时，对性能影响较大。
- 该功能使用频率很低，为了低频的使用而增加内存或 CPU 的使用率收益较低。

## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Related:** #xxx
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Documentation updated:** if relevant, docs or wiki should updated
