### PR TITLE
feat: 设置要跳过的文件的属性

### DIFF
--- a/src/DotVast.HashTool.WinUI.Core/Helpers/FileAttributesExtensions.cs
+++ b/src/DotVast.HashTool.WinUI.Core/Helpers/FileAttributesExtensions.cs
@@ -1,0 +1,24 @@
+using System.Runtime.CompilerServices;
+
+namespace DotVast.HashTool.WinUI.Core.Helpers;
+
+public static class FileAttributesExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasAnyFlag(this FileAttributes value, FileAttributes flags)
+    {
+        return (value & flags) != 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static FileAttributes AddFlag(this FileAttributes value, FileAttributes flags)
+    {
+        return value | flags;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static FileAttributes RemoveFlag(this FileAttributes value, FileAttributes flags)
+    {
+        return value & ~flags;
+    }
+}

--- a/src/DotVast.HashTool.WinUI/Constants.cs
+++ b/src/DotVast.HashTool.WinUI/Constants.cs
@@ -30,6 +30,7 @@ public static class DefaultAppearanceSettings
 
 public static class DefaultPreferencesSettings
 {
+    public const FileAttributes FileAttributesToSkipWhenFolderMode = FileAttributes.Hidden | FileAttributes.Offline | FileAttributes.System;
     public const bool FileExplorerContextMenusEnabled = true;
     public const bool IncludePreRelease = false;
     public const bool CheckForUpdatesOnStartup = false;

--- a/src/DotVast.HashTool.WinUI/Contracts/Services/Settings/IPreferencesSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Contracts/Services/Settings/IPreferencesSettingsService.cs
@@ -1,3 +1,4 @@
+using DotVast.HashTool.WinUI.Enums;
 using DotVast.HashTool.WinUI.Models;
 
 namespace DotVast.HashTool.WinUI.Contracts.Services.Settings;
@@ -12,6 +13,11 @@ public interface IPreferencesSettingsService : IBaseObservableSettings
     /// <param name="hashSetting">要保存的哈希设置.</param>
     /// <param name="forContextMenu">是否包含对资源管理器上下文菜单的修改.</param>
     void SaveHashSetting(HashSetting hashSetting, bool forContextMenu = false);
+
+    /// <summary>
+    /// 要跳过的文件的属性.
+    /// </summary>
+    FileAttributes FileAttributesToSkip { get; set; }
 
     /// <summary>
     /// 是否启用资源管理器注册的上下文菜单.

--- a/src/DotVast.HashTool.WinUI/Services/LocalSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/LocalSettingsService.cs
@@ -6,13 +6,11 @@ using System.Text.Json.Serialization.Metadata;
 using DotVast.HashTool.WinUI.Enums;
 using DotVast.HashTool.WinUI.Models;
 
-using Windows.Storage;
-
 namespace DotVast.HashTool.WinUI.Services;
 
 public sealed partial class LocalSettingsService : ILocalSettingsService
 {
-    private readonly ApplicationDataContainer _localSettings = ApplicationData.Current.LocalSettings;
+    private readonly Windows.Storage.ApplicationDataContainer _localSettings = Windows.Storage.ApplicationData.Current.LocalSettings;
 
     [return: NotNullIfNotNull(nameof(defaultValue))]
     public T? ReadSetting<T>(string key, T? defaultValue = default)
@@ -44,7 +42,7 @@ public sealed partial class LocalSettingsService : ILocalSettingsService
 
     public void SaveSetting<T>(string containerName, string key, T value)
     {
-        var container = _localSettings.CreateContainer(containerName, ApplicationDataCreateDisposition.Always);
+        var container = _localSettings.CreateContainer(containerName, Windows.Storage.ApplicationDataCreateDisposition.Always);
         container.Values[key] = JsonSerializer.Serialize(value, JsonContextForSettings.Default.GetTypeInfo<T>());
     }
 
@@ -54,6 +52,7 @@ public sealed partial class LocalSettingsService : ILocalSettingsService
     [JsonSerializable(typeof(bool))]
     [JsonSerializable(typeof(string))]
     [JsonSerializable(typeof(AppTheme))]
+    [JsonSerializable(typeof(FileAttributes))]
     [JsonSerializable(typeof(HashSetting))]
     private sealed partial class JsonContextForSettings : JsonSerializerContext
     {

--- a/src/DotVast.HashTool.WinUI/Services/Settings/PreferencesSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/Settings/PreferencesSettingsService.cs
@@ -16,6 +16,7 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
     public override Task InitializeAsync()
     {
         InitializeHashSettings();
+        _fileAttributesToSkip = Load(nameof(FileAttributesToSkip), DefaultPreferencesSettings.FileAttributesToSkipWhenFolderMode);
         _fileExplorerContextMenusEnabled = Load(nameof(FileExplorerContextMenusEnabled), DefaultPreferencesSettings.FileExplorerContextMenusEnabled);
         _includePreRelease = Load(nameof(IncludePreRelease), DefaultPreferencesSettings.IncludePreRelease);
         _checkForUpdatesOnStartup = Load(nameof(CheckForUpdatesOnStartup), DefaultPreferencesSettings.CheckForUpdatesOnStartup);
@@ -57,6 +58,15 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
         _localSettingsService.SaveSetting(SettingsContainerName.ContextMenu, "HashNames", hashNamesForContexMenu);
     }
     #endregion HashSettings
+
+    #region FileAttributesToSkip
+    private FileAttributes _fileAttributesToSkip;
+    public FileAttributes FileAttributesToSkip
+    {
+        get => _fileAttributesToSkip;
+        set => SetPropertyAndSave(value, ref _fileAttributesToSkip);
+    }
+    #endregion FileAttributesToSkip
 
     #region FileExplorerContextMenusEnabled
     private bool _fileExplorerContextMenusEnabled;

--- a/src/DotVast.HashTool.WinUI/Strings/en-US/Resources.resw
+++ b/src/DotVast.HashTool.WinUI/Strings/en-US/Resources.resw
@@ -78,11 +78,26 @@
   <data name="SettingsPage_CheckForUpdatesOnStartup.Header" xml:space="preserve">
     <value>Check for updates on startup</value>
   </data>
+  <data name="SettingsPage_FileAttributeHiddenToSkip.Header" xml:space="preserve">
+    <value>Skip hidden files</value>
+  </data>
+  <data name="SettingsPage_FileAttributeOfflineToSkip.Header" xml:space="preserve">
+    <value>Skip offline files</value>
+  </data>
+  <data name="SettingsPage_FileAttributeSystemToSkip.Header" xml:space="preserve">
+    <value>Skip system files</value>
+  </data>
   <data name="SettingsPage_FileExplorerContextMenusEnabled.Description" xml:space="preserve">
     <value>Whether to enable the context menus in file explorer</value>
   </data>
   <data name="SettingsPage_FileExplorerContextMenusEnabled.Header" xml:space="preserve">
     <value>Context Menus</value>
+  </data>
+  <data name="SettingsPage_FileOptions.Description" xml:space="preserve">
+    <value>Set the file behaviors when calculating</value>
+  </data>
+  <data name="SettingsPage_FileOptions.Header" xml:space="preserve">
+    <value>File Options</value>
   </data>
   <data name="SettingsPage_HashFontFamily.Description" xml:space="preserve">
     <value>Set the font family to display the hash</value>

--- a/src/DotVast.HashTool.WinUI/Strings/zh-Hans/Resources.resw
+++ b/src/DotVast.HashTool.WinUI/Strings/zh-Hans/Resources.resw
@@ -190,11 +190,26 @@
   <data name="SettingsPage_CheckForUpdatesOnStartup.Header" xml:space="preserve">
     <value>启动时检查更新</value>
   </data>
+  <data name="SettingsPage_FileAttributeHiddenToSkip.Header" xml:space="preserve">
+    <value>跳过隐藏文件</value>
+  </data>
+  <data name="SettingsPage_FileAttributeOfflineToSkip.Header" xml:space="preserve">
+    <value>跳过离线文件</value>
+  </data>
+  <data name="SettingsPage_FileAttributeSystemToSkip.Header" xml:space="preserve">
+    <value>跳过系统文件</value>
+  </data>
   <data name="SettingsPage_FileExplorerContextMenusEnabled.Description" xml:space="preserve">
     <value>是否启用资源管理器注册的上下文菜单</value>
   </data>
   <data name="SettingsPage_FileExplorerContextMenusEnabled.Header" xml:space="preserve">
     <value>上下文菜单</value>
+  </data>
+  <data name="SettingsPage_FileOptions.Description" xml:space="preserve">
+    <value>设置计算时的文件行为</value>
+  </data>
+  <data name="SettingsPage_FileOptions.Header" xml:space="preserve">
+    <value>文件选项</value>
   </data>
   <data name="SettingsPage_HashFontFamily.Description" xml:space="preserve">
     <value>设置显示哈希值的字体</value>

--- a/src/DotVast.HashTool.WinUI/Views/SettingsPage.xaml
+++ b/src/DotVast.HashTool.WinUI/Views/SettingsPage.xaml
@@ -64,6 +64,23 @@
                     <ToggleSwitch IsOn="{x:Bind ViewModel.FileExplorerContextMenusEnabled, Mode=TwoWay}" />
                 </labs:SettingsCard>
 
+                <labs:SettingsExpander x:Uid="SettingsPage_FileOptions">
+                    <labs:SettingsExpander.HeaderIcon>
+                        <FontIcon Glyph="&#xE7C3;" />
+                    </labs:SettingsExpander.HeaderIcon>
+                    <labs:SettingsExpander.Items>
+                        <labs:SettingsCard x:Uid="SettingsPage_FileAttributeHiddenToSkip">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.FileAttributeHiddenToSkip, Mode=TwoWay}" />
+                        </labs:SettingsCard>
+                        <labs:SettingsCard x:Uid="SettingsPage_FileAttributeOfflineToSkip">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.FileAttributeOfflineToSkip, Mode=TwoWay}" />
+                        </labs:SettingsCard>
+                        <labs:SettingsCard x:Uid="SettingsPage_FileAttributeSystemToSkip">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.FileAttributeSystemToSkip, Mode=TwoWay}" />
+                        </labs:SettingsCard>
+                    </labs:SettingsExpander.Items>
+                </labs:SettingsExpander>
+
                 <!-- 副标题: 个性化 -->
                 <TextBlock x:Uid="SettingsPage_Personalization" Style="{StaticResource GroupTitleTextBlockStyle}" />
 


### PR DESCRIPTION
## Summary

设置要跳过的文件的属性 `FileAttributesToSkip`。

## Detail / Remark

目前支持设置 `Hidden`、`Offline`、`System` 三种属性。

默认 `FileAttributesToSkip` 为 `Hidden | Offline | System`。

计算时，在任务准备阶段读取一次 `FileAttributesToSkip` 并在该任务的计算期间采用该设置。即任务计算过程中不响应相关设置，仅对新开始的计算响应相关设置。

### Documentation updated

[Wiki 设置](https://github.com/KiyanYang/DotVast.HashTool.WinUI/wiki/设置) 添加如下内容：

```md
## 文件选项

设置计算时的文件行为。

- 支持设置要跳过的文件的属性，支持`隐藏`、`离线`、`系统` 3 种文件属性。
```

## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Related:** #xxx
- [x] **Localization:** All end user facing strings can be localized
- [x] **Documentation updated:** if relevant, docs or wiki should updated

## 未决问题

- `Directory.GetFiles(String, String, EnumerationOptions)` 似乎可以满足要求，并且可以提供更加强大的功能，但是这种功能是否要移植到 `File` 模式下，有待考虑。

- 目前没有添加过多的前置功能（例如：递归文件夹，跳过无法访问的文件，文件名称筛选），放眼未来，基于功能和易用方面考虑，需要良好的界面设计和功能实现才能满足要求，目前个人能力有限，没有能力确保这些内容的良好实施，因此暂时搁置。从另一方面看，对于计算机相关人员可以更偏向命令行程序，因为命令行程序可以提供更加强大的功能，而对于普通用户更偏向界面程序。作为界面程序提供强大而复杂的功能是有一定风险的，作为个人开发者可能因此而需要处理过多无效问题。总而言之，本软件是简易的，适用于普通用户的，具备 Windows 风格的现代化哈希计算程序。
