### PR TITLE
fix: 修复结果页面中文件路径不响应高亮

### DIFF
--- a/src/DotVast.HashTool.WinUI/Strings/en-US/Resources.resw
+++ b/src/DotVast.HashTool.WinUI/Strings/en-US/Resources.resw
@@ -57,7 +57,7 @@
   <data name="RestartToApplyChange" xml:space="preserve">
     <value>Change will apply after restart</value>
   </data>
-  <data name="ResultsPage_FilterByContent.PlaceholderText" xml:space="preserve">
+  <data name="ResultsPage_Filter.PlaceholderText" xml:space="preserve">
     <value>Filter</value>
   </data>
   <data name="ResultsPage_Subtitle_TaskDetail.Text" xml:space="preserve">

--- a/src/DotVast.HashTool.WinUI/Strings/zh-Hans/Resources.resw
+++ b/src/DotVast.HashTool.WinUI/Strings/zh-Hans/Resources.resw
@@ -169,7 +169,7 @@
   <data name="RestartToApplyChange" xml:space="preserve">
     <value>重启后生效</value>
   </data>
-  <data name="ResultsPage_FilterByContent.PlaceholderText" xml:space="preserve">
+  <data name="ResultsPage_Filter.PlaceholderText" xml:space="preserve">
     <value>筛选</value>
   </data>
   <data name="ResultsPage_Subtitle_TaskDetail.Text" xml:space="preserve">

--- a/src/DotVast.HashTool.WinUI/ViewModels/ResultsViewModel.cs
+++ b/src/DotVast.HashTool.WinUI/ViewModels/ResultsViewModel.cs
@@ -20,11 +20,11 @@ public sealed partial class ResultsViewModel : ObservableObject, IViewModel, INa
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HashResultsFiltered))]
-    private string _hashResultsFilterByContent = string.Empty;
+    private string _hashResultsFilter = string.Empty;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HashResultsFiltered))]
-    private bool _hashResultsFilterByContentIsEnabled = false;
+    private bool _hashResultsFilterIsEnabled = false;
 
     private IList<HashResult>? _hashResultsFiltered;
 
@@ -32,12 +32,12 @@ public sealed partial class ResultsViewModel : ObservableObject, IViewModel, INa
     {
         get
         {
-            var filter = HashResultsFilterByContent;
+            var filter = HashResultsFilter;
             if (string.IsNullOrEmpty(filter))
             {
                 _hashResultsFiltered = HashTask?.Results;
             }
-            else if (HashResultsFilterByContentIsEnabled)
+            else if (HashResultsFilterIsEnabled)
             {
                 _hashResultsFiltered = HashTask?.Results?.Where(h =>
                     IgnoreCaseContains(h.Path, filter) || (h.Data?.Any(d => IgnoreCaseContains(d.Value, filter)) ?? false)
@@ -77,8 +77,8 @@ public sealed partial class ResultsViewModel : ObservableObject, IViewModel, INa
         if (value != null)
         {
             value.PropertyChanged += HashTask_PropertyChanged;
-            HashResultsFilterByContent = string.Empty;
-            HashResultsFilterByContentIsEnabled = value.State != HashTaskState.Waiting && value.State != HashTaskState.Working;
+            HashResultsFilter = string.Empty;
+            HashResultsFilterIsEnabled = value.State != HashTaskState.Waiting && value.State != HashTaskState.Working;
         }
     }
 
@@ -93,7 +93,7 @@ public sealed partial class ResultsViewModel : ObservableObject, IViewModel, INa
         {
             case nameof(HashTask.State):
                 // 当任务处于进行状态时, 禁用搜索
-                HashResultsFilterByContentIsEnabled = hashTask.State != HashTaskState.Waiting && hashTask.State != HashTaskState.Working;
+                HashResultsFilterIsEnabled = hashTask.State != HashTaskState.Waiting && hashTask.State != HashTaskState.Working;
                 break;
 
             case nameof(HashTask.Results):

--- a/src/DotVast.HashTool.WinUI/Views/ResultsPage.xaml
+++ b/src/DotVast.HashTool.WinUI/Views/ResultsPage.xaml
@@ -93,13 +93,13 @@
                         Style="{ThemeResource BodyLargeTextBlockStyle}"
                         Text="{x:Bind ViewModel.HashTask.Results.Count, Mode=OneWay}" />
                     <TextBox
-                        x:Uid="ResultsPage_FilterByContent"
+                        x:Uid="ResultsPage_Filter"
                         Grid.Column="2"
                         MinWidth="200"
                         HorizontalAlignment="Right"
-                        IsEnabled="{x:Bind ViewModel.HashResultsFilterByContentIsEnabled, Mode=OneWay}"
+                        IsEnabled="{x:Bind ViewModel.HashResultsFilterIsEnabled, Mode=OneWay}"
                         IsSpellCheckEnabled="False"
-                        Text="{x:Bind ViewModel.HashResultsFilterByContent, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        Text="{x:Bind ViewModel.HashResultsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </Grid>
 
                 <!-- 任务结果 -->
@@ -154,7 +154,7 @@
                                                     Text="{x:Bind Value}"
                                                     TextWrapping="Wrap">
                                                     <i:Interaction.Behaviors>
-                                                        <behaviors:TextBlockHighlightTextBehavior HighlightText="{Binding Path=HashResultsFilterByContent, Source={StaticResource ViewModel}}" />
+                                                        <behaviors:TextBlockHighlightTextBehavior HighlightText="{Binding Path=HashResultsFilter, Source={StaticResource ViewModel}}" />
                                                     </i:Interaction.Behaviors>
                                                 </TextBlock>
                                             </Grid>

--- a/src/DotVast.HashTool.WinUI/Views/ResultsPage.xaml
+++ b/src/DotVast.HashTool.WinUI/Views/ResultsPage.xaml
@@ -127,7 +127,11 @@
                                     Grid.Column="1"
                                     IsTextSelectionEnabled="True"
                                     Text="{x:Bind Path}"
-                                    TextWrapping="Wrap" />
+                                    TextWrapping="Wrap">
+                                    <i:Interaction.Behaviors>
+                                        <behaviors:TextBlockHighlightTextBehavior HighlightText="{Binding Path=HashResultsFilter, Source={StaticResource ViewModel}}" />
+                                    </i:Interaction.Behaviors>
+                                </TextBlock>
                                 <ItemsRepeater
                                     Grid.Row="1"
                                     Grid.Column="0"


### PR DESCRIPTION
## Summary

修复结果页面中文件路径不响应高亮。

## Detail / Remark

该 PR 包含以下内容：

- 筛选功能最初只针对结果中的文件路径，之后增加了对哈希结果的匹配。因此[重命名 FilterByContent 为 Filter 以符合当前的匹配行为](https://github.com/KiyanYang/DotVast.HashTool.WinUI/commit/c2c1558dcd16afcb996bfbf4c6f7386b30cdc486)。
- 添加高亮功能 ceeb0da 时，遗漏了对文件路径的高亮提示，对此进行修复。

## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Related:** #xxx
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Documentation updated:** if relevant, docs or wiki should updated
