### PR TITLE
feat: 哈希选择框添加浮出菜单以设置输出格式

### DIFF
--- a/src/DotVast.HashTool.WinUI/Services/Settings/PreferencesSettingsService.cs
+++ b/src/DotVast.HashTool.WinUI/Services/Settings/PreferencesSettingsService.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Kiyan Yang.
 // Licensed under the MIT License.
 
+using CommunityToolkit.Mvvm.Messaging;
+
 using DotVast.HashTool.WinUI.Constants;
 using DotVast.HashTool.WinUI.Contracts.Services.Settings;
+using DotVast.HashTool.WinUI.Enums;
 using DotVast.HashTool.WinUI.Models;
 
 namespace DotVast.HashTool.WinUI.Services.Settings;
@@ -30,7 +33,29 @@ internal sealed partial class PreferencesSettingsService : BaseObservableSetting
 
     public override Task StartupAsync()
     {
+        RegisterMessages();
         return Task.CompletedTask;
+    }
+
+    private void RegisterMessages()
+    {
+        WeakReferenceMessenger.Default.RegisterV<IPreferencesSettingsService, HashSetting, HashFormat>(this, EMT.HashSetting_Format, static (r, o, _) =>
+        {
+            r.SaveHashSetting(o);
+        });
+        WeakReferenceMessenger.Default.RegisterV<IPreferencesSettingsService, HashSetting, bool>(this, EMT.HashSetting_IsChecked, static (r, o, _) =>
+        {
+            r.SaveHashSetting(o);
+        });
+        WeakReferenceMessenger.Default.RegisterV<IPreferencesSettingsService, HashSetting, bool>(this, EMT.HashSetting_IsEnabledForApp, static (r, o, _) =>
+        {
+            r.SaveHashSetting(o);
+        });
+
+        WeakReferenceMessenger.Default.RegisterV<IPreferencesSettingsService, HashSetting, bool>(this, EMT.HashSetting_IsEnabledForContextMenu, static (r, o, _) =>
+        {
+            r.SaveHashSetting(o, true);
+        });
     }
 
     #region HashSettings

--- a/src/DotVast.HashTool.WinUI/ViewModels/HashSettingsViewModel.cs
+++ b/src/DotVast.HashTool.WinUI/ViewModels/HashSettingsViewModel.cs
@@ -3,12 +3,11 @@
 
 using DotVast.HashTool.WinUI.Contracts.Services.Settings;
 using DotVast.HashTool.WinUI.Enums;
-using DotVast.HashTool.WinUI.Helpers;
 using DotVast.HashTool.WinUI.Models;
 
 namespace DotVast.HashTool.WinUI.ViewModels;
 
-public sealed partial class HashSettingsViewModel : SimpleObservableRecipient, IViewModel, INavigationAware
+public sealed partial class HashSettingsViewModel : ObservableObject, IViewModel
 {
     private readonly IPreferencesSettingsService _preferencesSettingsService;
 
@@ -20,40 +19,4 @@ public sealed partial class HashSettingsViewModel : SimpleObservableRecipient, I
     public IReadOnlyList<HashSetting> HashSettings => _preferencesSettingsService.HashSettings;
 
     public IReadOnlyList<HashFormat> HashFormats { get; } = Enum.GetValues<HashFormat>();
-
-    #region Messenger
-
-    protected override void OnActivated()
-    {
-        Messenger.RegisterV<HashSettingsViewModel, HashSetting, HashFormat>(this, EMT.HashSetting_Format, static (r, o, _) =>
-        {
-            r._preferencesSettingsService.SaveHashSetting(o);
-        });
-
-        Messenger.RegisterV<HashSettingsViewModel, HashSetting, bool>(this, EMT.HashSetting_IsEnabledForApp, static (r, o, _) =>
-        {
-            r._preferencesSettingsService.SaveHashSetting(o);
-        });
-
-        Messenger.RegisterV<HashSettingsViewModel, HashSetting, bool>(this, EMT.HashSetting_IsEnabledForContextMenu, static (r, o, _) =>
-        {
-            r._preferencesSettingsService.SaveHashSetting(o, true);
-        });
-    }
-
-    #endregion Messenger
-
-    #region INavigationAware
-
-    void INavigationAware.OnNavigatedTo(object? parameter)
-    {
-        IsActive = true;
-    }
-
-    void INavigationAware.OnNavigatedFrom()
-    {
-        IsActive = false;
-    }
-
-    #endregion INavigationAware
 }

--- a/src/DotVast.HashTool.WinUI/ViewModels/HomeViewModel.cs
+++ b/src/DotVast.HashTool.WinUI/ViewModels/HomeViewModel.cs
@@ -104,7 +104,6 @@ public sealed partial class HomeViewModel : SimpleObservableRecipient, IViewMode
 
         Messenger.RegisterV<HomeViewModel, HashSetting, bool>(this, EMT.HashSetting_IsChecked, static (r, o, _) =>
         {
-            r._preferencesSettingsService.SaveHashSetting(o);
             r.CreateTaskCommand.NotifyCanExecuteChanged();
         });
     }

--- a/src/DotVast.HashTool.WinUI/Views/Controls/HashCheckBox.xaml
+++ b/src/DotVast.HashTool.WinUI/Views/Controls/HashCheckBox.xaml
@@ -1,0 +1,30 @@
+<UserControl
+    x:Class="DotVast.HashTool.WinUI.Views.Controls.HashCheckBox"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:enums="using:DotVast.HashTool.WinUI.Enums">
+
+    <CheckBox Content="{x:Bind Setting.Name, Mode=OneWay}" IsChecked="{x:Bind Setting.IsChecked, Mode=TwoWay}" />
+
+    <UserControl.ContextFlyout>
+        <MenuFlyout>
+            <!-- about GroupName, see https://github.com/microsoft/microsoft-ui-xaml/issues/6816 -->
+            <RadioMenuFlyoutItem
+                Click="Base16UpperRadioItem_Click"
+                GroupName="{x:Bind _guid}"
+                IsChecked="{x:Bind ToHashFormatRadioItemIsChecked(Setting.Format, enums:HashFormat.Base16Upper), Mode=OneWay}"
+                Text="{x:Bind enums:HashFormatExtensions.ToDisplay(enums:HashFormat.Base16Upper)}" />
+            <RadioMenuFlyoutItem
+                Click="Base16LowerRadioItem_Click"
+                GroupName="{x:Bind _guid}"
+                IsChecked="{x:Bind ToHashFormatRadioItemIsChecked(Setting.Format, enums:HashFormat.Base16Lower), Mode=OneWay}"
+                Text="{x:Bind enums:HashFormatExtensions.ToDisplay(enums:HashFormat.Base16Lower)}" />
+            <RadioMenuFlyoutItem
+                Click="Base64RadioItem_Click"
+                GroupName="{x:Bind _guid}"
+                IsChecked="{x:Bind ToHashFormatRadioItemIsChecked(Setting.Format, enums:HashFormat.Base64), Mode=OneWay}"
+                Text="{x:Bind enums:HashFormatExtensions.ToDisplay(enums:HashFormat.Base64)}" />
+        </MenuFlyout>
+    </UserControl.ContextFlyout>
+
+</UserControl>

--- a/src/DotVast.HashTool.WinUI/Views/Controls/HashCheckBox.xaml.cs
+++ b/src/DotVast.HashTool.WinUI/Views/Controls/HashCheckBox.xaml.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Kiyan Yang.
+// Licensed under the MIT License.
+
+using DotVast.HashTool.WinUI.Enums;
+using DotVast.HashTool.WinUI.Models;
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DotVast.HashTool.WinUI.Views.Controls;
+
+public sealed partial class HashCheckBox : UserControl
+{
+    private readonly Guid _guid = Guid.NewGuid();
+
+    public HashSetting Setting
+    {
+        get { return (HashSetting)GetValue(SettingProperty); }
+        set { SetValue(SettingProperty, value); }
+    }
+
+    public static readonly DependencyProperty SettingProperty =
+        DependencyProperty.Register(nameof(Setting), typeof(HashSetting), typeof(HashCheckBox), new PropertyMetadata(null));
+
+    public HashCheckBox()
+    {
+        InitializeComponent();
+    }
+
+    private void Base16UpperRadioItem_Click(object sender, RoutedEventArgs e)
+    {
+        Setting.Format = HashFormat.Base16Upper;
+    }
+
+    private void Base16LowerRadioItem_Click(object sender, RoutedEventArgs e)
+    {
+        Setting.Format = HashFormat.Base16Lower;
+    }
+
+    private void Base64RadioItem_Click(object sender, RoutedEventArgs e)
+    {
+        Setting.Format = HashFormat.Base64;
+    }
+
+    private bool ToHashFormatRadioItemIsChecked(HashFormat format, HashFormat targetFormat)
+    {
+        return format == targetFormat;
+    }
+}

--- a/src/DotVast.HashTool.WinUI/Views/HomePage.xaml
+++ b/src/DotVast.HashTool.WinUI/Views/HomePage.xaml
@@ -122,7 +122,7 @@
                         </ItemsRepeater.Layout>
                         <ItemsRepeater.ItemTemplate>
                             <DataTemplate x:DataType="models:HashSetting">
-                                <CheckBox Content="{x:Bind Name}" IsChecked="{x:Bind IsChecked, Mode=TwoWay}" />
+                                <controls:HashCheckBox Setting="{x:Bind}" />
                             </DataTemplate>
                         </ItemsRepeater.ItemTemplate>
                     </ItemsRepeater>


### PR DESCRIPTION
## Summary

哈希选择框添加浮出菜单以设置输出格式。

## Detail / Remark

- [优化 HashSetting 的保存](https://github.com/KiyanYang/DotVast.HashTool.WinUI/commit/122ee7cbbf7ce28548840b1895c309ec371d373c)
- 哈希选择框添加浮出菜单以设置输出格式，`RadioMenuFlyoutItem` 的组区域不是父元素（不知是 Feat 还是 Bug），因此需要设置 `GUID` 以区分不同哈希算法的菜单。

## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Related:** #xxx
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Documentation updated:** if relevant, docs or wiki should updated
