### PR TITLE
pref: 优化 QuickXorHash 性能

### DIFF
--- a/src/DotVast.HashTool.WinUI/Enums/HashKind.cs
+++ b/src/DotVast.HashTool.WinUI/Enums/HashKind.cs
@@ -112,7 +112,7 @@ internal static class HashKindExtensions
             HashKind.XxHash64 => new System.IO.Hashing.XxHash64().ToHashAlgorithm(),
             HashKind.XxHash3 => new System.IO.Hashing.XxHash3().ToHashAlgorithm(),
             HashKind.XxHash128 => new System.IO.Hashing.XxHash128().ToHashAlgorithm(),
-            HashKind.QuickXor => new QuickXorHash(),
+            HashKind.QuickXor => new Core.Hashes.QuickXorHash(),
             HashKind.Ed2k => new Ed2k(),
             HashKind.HAS_160 => HashLib4CSharp.Base.HashFactory.Crypto.CreateHAS160().ToHashAlgorithm(),
             _ => throw new ArgumentOutOfRangeException(nameof(hashKind)),

--- a/src/DotVast.HashTool.WinUI/ViewModels/LicensesViewModel.cs
+++ b/src/DotVast.HashTool.WinUI/ViewModels/LicensesViewModel.cs
@@ -32,8 +32,6 @@ public sealed class LicensesViewModel : IViewModel
         new("System.IO.Hashing", License.MIT, NugetLicenseUrl.MIT, "https://www.nuget.org/packages/System.IO.Hashing"),
 
         new("WinUIEx", License.Apache_2_0, NugetLicenseUrl.Apache_2_0, "https://www.nuget.org/packages/WinUIEx"),
-
-        new("QuickXorHash.cs", License.MIT, "https://gist.github.com/rgregg/c07a91964300315c6c3e77f7b5b861e4", "https://gist.github.com/rgregg/c07a91964300315c6c3e77f7b5b861e4"),
     };
 }
 


### PR DESCRIPTION
## Summary

优化 QuickXorHash 性能.

## Detail / Remark

之前官方文档中的[实现](https://gist.github.com/rgregg/c07a91964300315c6c3e77f7b5b861e4)计算速度较慢，参考 [namazso/QuickXorHash](https://github.com/namazso/QuickXorHash) 优化 QuickXor 的计算速度。

<details><summary>Benchmark</summary>
<p>

```cs
using System.Numerics;
using System.Runtime.InteropServices;
using System.Security.Cryptography;

using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Engines;
using BenchmarkDotNet.Jobs;
using BenchmarkDotNet.Running;

namespace DotVast.Benchmark;

internal class Program
{
    static void Main(string[] args)
    {
        BenchmarkRunner.Run<Benchy>();
    }
}

[MemoryDiagnoser(false)]
[SimpleJob(RunStrategy.Throughput, RuntimeMoniker.Net70)]
public class Benchy
{
    private readonly QuickXorHash _quickXorHash = new();
    private readonly QuickXorHashNew _quickXorHashNew = new();

    [Params(32, 1024, 1024 * 32, 1024 * 1024, 1024 * 1024 * 32)]
    public int Length { get; set; }

    private byte[] bytes;

    [GlobalSetup]
    public void Setup()
    {
        var random = new Random(9865);
        bytes = new byte[Length];
        random.NextBytes(bytes);
    }

    [Benchmark(Baseline = true)]
    public byte[] QuickXorHash()
    {
        return _quickXorHash.ComputeHash(bytes);
    }

    [Benchmark]
    public byte[] QuickXorHashNew()
    {
        return _quickXorHashNew.ComputeHash(bytes);
    }
}

public sealed class QuickXorHash : HashAlgorithm
{
    private const int BitsInLastCell = 32;
    private const byte Shift = 11;
    private const int Threshold = 600;
    private const byte WidthInBits = 160;

    private UInt64[] _data;
    private Int64 _lengthSoFar;
    private int _shiftSoFar;

    public QuickXorHash()
    {
        this.Initialize();
    }

    protected override void HashCore(byte[] array, int ibStart, int cbSize)
    {
        unchecked
        {
            int currentShift = this._shiftSoFar;

            // The bitvector where we'll start xoring
            int vectorArrayIndex = currentShift / 64;

            // The position within the bit vector at which we begin xoring
            int vectorOffset = currentShift % 64;
            int iterations = Math.Min(cbSize, QuickXorHash.WidthInBits);

            for (int i = 0; i < iterations; i++)
            {
                bool isLastCell = vectorArrayIndex == this._data.Length - 1;
                int bitsInVectorCell = isLastCell ? QuickXorHash.BitsInLastCell : 64;

                // There's at least 2 bitvectors before we reach the end of the array
                if (vectorOffset <= bitsInVectorCell - 8)
                {
                    for (int j = ibStart + i; j < cbSize + ibStart; j += QuickXorHash.WidthInBits)
                    {
                        this._data[vectorArrayIndex] ^= (ulong)array[j] << vectorOffset;
                    }
                }
                else
                {
                    int index1 = vectorArrayIndex;
                    int index2 = isLastCell ? 0 : (vectorArrayIndex + 1);
                    byte low = (byte)(bitsInVectorCell - vectorOffset);

                    byte xoredByte = 0;
                    for (int j = ibStart + i; j < cbSize + ibStart; j += QuickXorHash.WidthInBits)
                    {
                        xoredByte ^= array[j];
                    }
                    this._data[index1] ^= (ulong)xoredByte << vectorOffset;
                    this._data[index2] ^= (ulong)xoredByte >> low;
                }
                vectorOffset += QuickXorHash.Shift;
                while (vectorOffset >= bitsInVectorCell)
                {
                    vectorArrayIndex = isLastCell ? 0 : vectorArrayIndex + 1;
                    vectorOffset -= bitsInVectorCell;
                }
            }

            // Update the starting position in a circular shift pattern
            this._shiftSoFar = (this._shiftSoFar + QuickXorHash.Shift * (cbSize % QuickXorHash.WidthInBits)) % QuickXorHash.WidthInBits;
        }

        this._lengthSoFar += cbSize;
    }

    protected override byte[] HashFinal()
    {
        // Create a byte array big enough to hold all our data
        byte[] rgb = new byte[(QuickXorHash.WidthInBits - 1) / 8 + 1];

        // Block copy all our bitvectors to this byte array
        for (Int32 i = 0; i < this._data.Length - 1; i++)
        {
            Buffer.BlockCopy(
                BitConverter.GetBytes(this._data[i]), 0,
                rgb, i * 8,
                8);
        }

        Buffer.BlockCopy(
            BitConverter.GetBytes(this._data[this._data.Length - 1]), 0,
            rgb, (this._data.Length - 1) * 8,
            rgb.Length - (this._data.Length - 1) * 8);

        // XOR the file length with the least significant bits
        // Note that GetBytes is architecture-dependent, so care should
        // be taken with porting. The expected value is 8-bytes in length in little-endian format
        var lengthBytes = BitConverter.GetBytes(this._lengthSoFar);
        System.Diagnostics.Debug.Assert(lengthBytes.Length == 8);
        for (int i = 0; i < lengthBytes.Length; i++)
        {
            rgb[(QuickXorHash.WidthInBits / 8) - lengthBytes.Length + i] ^= lengthBytes[i];
        }

        return rgb;
    }

    public override sealed void Initialize()
    {
        this._data = new ulong[(QuickXorHash.WidthInBits - 1) / 64 + 1];
        this._shiftSoFar = 0;
        this._lengthSoFar = 0;
    }

    public override int HashSize
    {
        get
        {
            return QuickXorHash.WidthInBits;
        }
    }
}

public sealed class QuickXorHashNew : HashAlgorithm
{
    private const int HashSizeInBytes = 20;
    private const int HashSizeInBits = HashSizeInBytes * 8;
    private const byte Shift = 11;
    private const int BlockExLength = HashSizeInBits * Shift;

    private readonly byte[] _blockEx = new byte[BlockExLength];
    private long _lengthSoFar;

    public QuickXorHashNew()
    {
        HashSizeValue = HashSizeInBytes;
        Initialize();
    }

    public override void Initialize()
    {
        Array.Clear(_blockEx);
        _lengthSoFar = 0;
    }

    protected override void HashCore(byte[] array, int ibStart, int cbSize)
    {
        var count = Vector<byte>.Count;
        while (cbSize > count)
        {
            int blockExIndex;
            blockExIndex = (int)(_lengthSoFar % BlockExLength);
            var blockExVecSpan = MemoryMarshal.Cast<byte, Vector<byte>>(_blockEx.AsSpan(blockExIndex));
            var arrayVecSpan = MemoryMarshal.Cast<byte, Vector<byte>>(array.AsSpan(ibStart, cbSize));
            var length = Math.Min(blockExVecSpan.Length, arrayVecSpan.Length);
            for (var i = 0; i < length; i++)
            {
                blockExVecSpan[i] ^= arrayVecSpan[i];
            }
            _lengthSoFar += length * count;
            ibStart += length * count;
            cbSize -= length * count;

            while (_lengthSoFar % BlockExLength != 0 && cbSize > 0)
            {
                _blockEx[_lengthSoFar % BlockExLength] ^= array[ibStart];
                _lengthSoFar++;
                ibStart++;
                cbSize--;
            }
        }
        while (cbSize > 0)
        {
            _blockEx[_lengthSoFar % BlockExLength] ^= array[ibStart];
            _lengthSoFar++;
            ibStart++;
            cbSize--;
        }
    }

    protected override byte[] HashFinal()
    {
        Span<byte> hash = stackalloc byte[HashSizeInBytes + 1];
        for (var i = 0; i < BlockExLength; i++)
        {
            var shift = i * Shift % HashSizeInBits;
            var shiftBytes = shift / 8;
            var shiftBits = shift % 8;
            var shifted = _blockEx[i] << shiftBits;
            hash[shiftBytes] ^= (byte)shifted;
            hash[shiftBytes + 1] ^= (byte)(shifted >> 8);
        }
        hash[0] ^= hash[20];

        hash[12] ^= (byte)(_lengthSoFar >> 0);
        hash[13] ^= (byte)(_lengthSoFar >> 8);
        hash[14] ^= (byte)(_lengthSoFar >> 16);
        hash[15] ^= (byte)(_lengthSoFar >> 24);
        hash[16] ^= (byte)(_lengthSoFar >> 32);
        hash[17] ^= (byte)(_lengthSoFar >> 40);
        hash[18] ^= (byte)(_lengthSoFar >> 48);
        hash[19] ^= (byte)(_lengthSoFar >> 56);

        return hash[..HashSizeInBytes].ToArray();
    }
}
```

</p>
</details> 

<details><summary>Benchmark Result</summary>
<p>

```txt
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
AMD Ryzen 7 6800H with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host]     : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
  Job-TFGNBP : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2

Runtime=.NET 7.0  RunStrategy=Throughput

|          Method |   Length |            Mean |           Error |          StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
|---------------- |--------- |----------------:|----------------:|----------------:|------:|--------:|----------:|------------:|
|    QuickXorHash |       32 |        148.6 ns |         1.32 ns |         1.24 ns |  1.00 |    0.00 |     272 B |        1.00 |
| QuickXorHashNew |       32 |      4,472.9 ns |         9.53 ns |         8.44 ns | 30.10 |    0.27 |      96 B |        0.35 |
|                 |          |                 |                 |                 |       |         |           |             |
|    QuickXorHash |     1024 |      1,065.5 ns |         8.41 ns |         7.46 ns |  1.00 |    0.00 |     272 B |        1.00 |
| QuickXorHashNew |     1024 |      4,424.3 ns |        11.44 ns |        10.70 ns |  4.15 |    0.03 |      96 B |        0.35 |
|                 |          |                 |                 |                 |       |         |           |             |
|    QuickXorHash |    32768 |     19,767.1 ns |        54.09 ns |        47.95 ns |  1.00 |    0.00 |     272 B |        1.00 |
| QuickXorHashNew |    32768 |      4,925.2 ns |         8.96 ns |         7.49 ns |  0.25 |    0.00 |      96 B |        0.35 |
|                 |          |                 |                 |                 |       |         |           |             |
|    QuickXorHash |  1048576 |    617,592.8 ns |     3,509.51 ns |     3,282.80 ns |  1.00 |    0.00 |     273 B |        1.00 |
| QuickXorHashNew |  1048576 |     22,221.4 ns |        38.35 ns |        34.00 ns |  0.04 |    0.00 |      96 B |        0.35 |
|                 |          |                 |                 |                 |       |         |           |             |
|    QuickXorHash | 33554432 | 69,947,832.2 ns | 1,238,466.43 ns | 1,158,462.27 ns |  1.00 |    0.00 |     372 B |        1.00 |
| QuickXorHashNew | 33554432 |  1,402,873.8 ns |    10,967.48 ns |     9,158.34 ns |  0.02 |    0.00 |      97 B |        0.26 |
```

</p>
</details> 

## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Related:** #xxx
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Documentation updated:** if relevant, docs or wiki should updated
